### PR TITLE
ruleset-add command

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,6 +12,10 @@
 
   ```bash
   npm link
+
+  # if you have the NPM package installed
+  # you'll need to force this link
+  npm link --force
   ```
 
 - You're all set now, open help to see a list of commands

--- a/graphql/queries.js
+++ b/graphql/queries.js
@@ -27,3 +27,12 @@ export const GET_RULESETS_FOR_CLIENT = gql`
     }
   }
 `;
+
+export const GET_RULESET = gql`
+  query getRuleset($name: String!) {
+    ruleSet(name: $name) {
+      id
+      name
+    }
+  }
+`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@codiga/cli",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codiga/cli",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A Codiga CLI used to integrate Codiga easily in your projects",
   "homepage": "https://github.com/codiga/codiga-cli",
   "repository": {

--- a/src/addRuleset.js
+++ b/src/addRuleset.js
@@ -1,4 +1,5 @@
 import { writeFile } from "fs/promises";
+import { isTestMode } from "../tests/test-utils";
 import {
   ACTION_RULESET_ADD,
   ACTION_TOKEN_ADD,

--- a/src/addRuleset.js
+++ b/src/addRuleset.js
@@ -1,0 +1,137 @@
+import { writeFile } from "fs/promises";
+import {
+  ACTION_RULESET_ADD,
+  ACTION_TOKEN_ADD,
+  CODIGA_CONFIG_FILE,
+} from "../utils/constants";
+import { readFile, parseYamlFile } from "../utils/file";
+import { getGitDirectory } from "../utils/git";
+import {
+  printCommandSuggestion,
+  printEmptyLine,
+  printFailure,
+  printInfo,
+  printSuggestion,
+} from "../utils/print";
+import { convertRulesetsToString, getRuleset } from "../utils/ruleset";
+
+/**
+ * Creates a codiga.yml file's content with the rulesets given
+ * Note: because this overrides the file, you need to pass any old rulesets that should remain
+ * @param {string[]} rulesets
+ */
+export async function createCodigaYml(codigaFileLocation, rulesets) {
+  if (isTestMode) return;
+  try {
+    await writeFile(codigaFileLocation, convertRulesetsToString(rulesets), {
+      encoding: "utf-8",
+    });
+  } catch (err) {
+    // console.debug(err);
+    printEmptyLine();
+    printFailure(`We were unable to write to: ${codigaFileLocation}`);
+    printSuggestion(
+      " ↳ Please try again and contact us, if the issue persists:",
+      "https://app.codiga.io/support"
+    );
+    printEmptyLine();
+    process.exit(1);
+  }
+}
+
+/**
+ * Handles adding a ruleset to a codiga.yml file
+ * @param {string[]} rulesetNames
+ */
+export async function addRuleset(rulesetNames) {
+  // TODO - change to a prompt when no rulesets are given
+  const rulesetName = rulesetNames[0];
+  if (!rulesetName) {
+    printEmptyLine();
+    printFailure("You need to specify a ruleset to add");
+    printSuggestion(
+      " ↳ You can search for rulesets here:",
+      "https://app.codiga.io/hub/rulesets"
+    );
+    printCommandSuggestion(
+      " ↳ Then follow this command structure:",
+      `${ACTION_RULESET_ADD} <ruleset-name>`
+    );
+    printEmptyLine();
+    process.exit(1);
+  }
+
+  // Check if the ruleset exists before continuing onwards
+  const ruleset = await getRuleset({ name: rulesetName });
+  if (!ruleset) {
+    printEmptyLine();
+    printFailure(
+      "That ruleset either doesn't exist or you lack the permissions to access it"
+    );
+    printCommandSuggestion(
+      " ↳ Ensure you have a Codiga API token set with one of the following commands:",
+      ACTION_TOKEN_ADD
+    );
+    printSuggestion(
+      " ↳ You can find more rulesets here:",
+      "https://app.codiga.io/hub/rulesets"
+    );
+    printEmptyLine();
+    process.exit(1);
+  }
+
+  /**
+   * Get the `codiga.yml` file location and content.
+   * We'll look in the git directory, if it exists.
+   * Otherwise, we'll look in the current directory
+   */
+  const gitDirectory = getGitDirectory();
+  const dir = gitDirectory || process.cwd();
+  const codigaFileLocation = `${dir}/${CODIGA_CONFIG_FILE}`;
+  const codigaFileContent = readFile(codigaFileLocation);
+
+  /**
+   * If we found a `codiga.yml` file, add the rule to it
+   * If we don't find a `codiga.yml` file, create the file and add the rule to it
+   */
+  if (codigaFileContent) {
+    const parsedFile = parseYamlFile(codigaFileContent, codigaFileLocation);
+    const codigaRulesets = parsedFile.rulesets;
+    if (codigaRulesets.includes(rulesetName)) {
+      printEmptyLine();
+      printInfo(
+        `The ruleset (${rulesetName}) already exists in your \`codiga.yml\``
+      );
+      printSuggestion;
+      printEmptyLine();
+      process.exit(1);
+    } else {
+      // adding the new ruleset to the file
+      await createCodigaYml(codigaFileLocation, [
+        ...codigaRulesets,
+        rulesetName,
+      ]);
+      printSuggestion(
+        `We added ${rulesetName} to your codiga.yml file:`,
+        codigaFileLocation
+      );
+      printSuggestion(
+        " ↳ Find more rulesets to add here:",
+        "https://app.codiga.io/hub/rulesets"
+      );
+    }
+  } else {
+    // creating a new codiga.yml with the ruleset here
+    await createCodigaYml(codigaFileLocation, [rulesetName]);
+    printSuggestion(
+      `No codiga.yml file found, so we created one and added ${rulesetName} to it:`,
+      codigaFileLocation
+    );
+    printSuggestion(
+      " ↳ Find more rulesets to add here:",
+      "https://app.codiga.io/hub/rulesets"
+    );
+  }
+
+  process.exit(0);
+}

--- a/src/checkPush.js
+++ b/src/checkPush.js
@@ -34,6 +34,18 @@ function getChangedFilePaths(remoteSHA, localSHA) {
     remoteSHA,
     localSHA,
   ]);
+  if (!diff) {
+    printEmptyLine();
+    printFailure(
+      `We were unable to get the difference between ${remoteSHA} and ${localSHA}`
+    );
+    printSuggestion(
+      " ↳ Please review your SHAs above and contact support, if needed:",
+      "https://app.codiga.io/support"
+    );
+    printEmptyLine();
+    process.exit(1);
+  }
   return diff.split("\n").filter((s) => s);
 }
 

--- a/src/checkPush.js
+++ b/src/checkPush.js
@@ -90,11 +90,10 @@ export function checkSHAs(remoteShaArg, localShaArg) {
  * @param {string} localSHA
  */
 export async function checkPush(remoteShaArg, localShaArg) {
-  console.log(remoteShaArg, localShaArg);
   if (!remoteShaArg || !localShaArg) {
     printFailure("You need to pass in both remote and local SHA values");
     printSuggestion(
-      "Refer to our documentation for more info:",
+      " ↳ Refer to our documentation for more info:",
       "https://doc.codiga.io/docs/cli/#analysis-and-report-issues-between-two-commits"
     );
     process.exit(1);

--- a/src/checkPush.js
+++ b/src/checkPush.js
@@ -90,6 +90,16 @@ export function checkSHAs(remoteShaArg, localShaArg) {
  * @param {string} localSHA
  */
 export async function checkPush(remoteShaArg, localShaArg) {
+  console.log(remoteShaArg, localShaArg);
+  if (!remoteShaArg || !localShaArg) {
+    printFailure("You need to pass in both remote and local SHA values");
+    printSuggestion(
+      "Refer to our documentation for more info:",
+      "https://doc.codiga.io/docs/cli/#analysis-and-report-issues-between-two-commits"
+    );
+    process.exit(1);
+  }
+
   // ensure that there's a git directory to continue
   getRootDirectory();
 

--- a/src/checkPush.js
+++ b/src/checkPush.js
@@ -1,7 +1,7 @@
 import {
   executeGitCommand,
   findClosestSha,
-  getRootDirectory,
+  getGitDirectoryRequired,
 } from "../utils/git";
 import {
   getRulesetsFromCodigaFile,
@@ -100,7 +100,7 @@ export async function checkPush(remoteShaArg, localShaArg) {
   }
 
   // ensure that there's a git directory to continue
-  getRootDirectory();
+  getGitDirectoryRequired();
 
   // check and verify the SHA args
   const { remoteSha, localSha } = checkSHAs(remoteShaArg, localShaArg);

--- a/src/cli.js
+++ b/src/cli.js
@@ -4,6 +4,7 @@ import {
   ACTION_TOKEN_ADD,
   ACTION_TOKEN_CHECK,
   ACTION_TOKEN_DELETE,
+  ACTION_RULESET_ADD,
   OPTION_LANGUAGE,
   OPTION_LOCAL_SHA,
   OPTION_REMOTE_SHA,
@@ -19,6 +20,7 @@ import {
   checkCodigaToken,
   deleteCodigaToken,
 } from "./codigaToken";
+import { addRuleset } from "./addRuleset";
 
 /**
  * Parses the given command into a readable object to execute
@@ -50,6 +52,7 @@ function parseCommand(args) {
         },
       }
     )
+    .command(ACTION_RULESET_ADD, "Add a ruleset to a `codiga.yml` file")
     .help(true).argv;
 
   // format any actions into a single object with default values
@@ -58,6 +61,7 @@ function parseCommand(args) {
     [ACTION_TOKEN_CHECK]: yargV["_"].includes(ACTION_TOKEN_CHECK) || false,
     [ACTION_TOKEN_DELETE]: yargV["_"].includes(ACTION_TOKEN_DELETE) || false,
     [ACTION_GIT_PUSH_HOOK]: yargV["_"].includes(ACTION_GIT_PUSH_HOOK) || false,
+    [ACTION_RULESET_ADD]: yargV["_"].includes(ACTION_RULESET_ADD) || false,
   };
 
   // how many actions were detected in the command ran
@@ -90,10 +94,13 @@ function parseCommand(args) {
     [OPTION_LANGUAGE]: yargV[OPTION_LANGUAGE] || null,
   };
 
+  const parameters = yargV["_"].slice(1);
+
   // the parsed/formatted result
   return {
     action: selectedAction,
     options,
+    parameters,
   };
 }
 
@@ -105,6 +112,7 @@ export async function cli(args) {
       [OPTION_REMOTE_SHA]: remoteSha,
       [OPTION_LANGUAGE]: language,
     },
+    parameters,
   } = parseCommand(args);
 
   switch (action) {
@@ -116,6 +124,8 @@ export async function cli(args) {
       return await deleteCodigaToken();
     case ACTION_GIT_PUSH_HOOK:
       return await checkPush(remoteSha, localSha);
+    case ACTION_RULESET_ADD:
+      return await addRuleset(parameters);
     default:
       return (() => {
         printEmptyLine();

--- a/tests/add-ruleset.test.js
+++ b/tests/add-ruleset.test.js
@@ -1,0 +1,29 @@
+import { ACTION_RULESET_ADD } from "../utils/constants";
+import { executeCommand } from "./test-utils";
+
+describe("codiga ruleset-add", () => {
+  test("an invalid ruleset name should throw", async () => {
+    // run the command
+    await executeCommand([ACTION_RULESET_ADD, "invalid-ruleset"])
+      .then((output) => {
+        expect(output).toBeUndefined();
+      })
+      .catch(({ stdout }) => {
+        expect(stdout).toMatch(
+          /That ruleset either doesn't exist or you lack the permissions to access it/
+        );
+      });
+  });
+
+  test("a ruleset that's already present should throw", async () => {
+    // run the command
+    await executeCommand([ACTION_RULESET_ADD, "great-ruleset"])
+      .then((output) => {
+        expect(output).toBeUndefined();
+      })
+      .catch(({ stdout }) => {
+        console.log(stdout);
+        expect(stdout).toMatch(/already exists in your/);
+      });
+  });
+});

--- a/tests/check-push.test.js
+++ b/tests/check-push.test.js
@@ -4,11 +4,15 @@ import { executeCommand } from "./test-utils";
 describe("codiga git-push-hook", () => {
   test("check for same SHAs", async () => {
     // run the command
-    await executeCommand([ACTION_GIT_PUSH_HOOK, "1234", "1234"]).then(
-      (output) => {
-        expect(output).toMatch(/Remote and local SHA are the same/);
-      }
-    );
+    await executeCommand([
+      ACTION_GIT_PUSH_HOOK,
+      "--remote-sha",
+      "1234",
+      "--local-sha",
+      "1234",
+    ]).then((output) => {
+      expect(output).toMatch(/Remote and local SHA are the same/);
+    });
   });
 
   test("check for closest SHA", async () => {

--- a/tests/fixtures/codiga.yml
+++ b/tests/fixtures/codiga.yml
@@ -1,3 +1,5 @@
 rulesets:
   - react-best-practices
   - jsx-a11y
+  - great-ruleset
+  

--- a/tests/fixtures/rulesetMock.js
+++ b/tests/fixtures/rulesetMock.js
@@ -1,0 +1,27 @@
+export const mockedRuleset1 = {
+  id: 1,
+  name: "test-ruleset",
+};
+
+export const mockedRuleset2 = {
+  id: 2,
+  name: "great-ruleset",
+};
+
+export const mockedRuleset3 = {
+  id: 3,
+  name: "fantastic-ruleset",
+};
+
+export function getRulesetMock(rulesetName) {
+  switch (rulesetName) {
+    case "test-ruleset":
+      return mockedRuleset1;
+    case "great-ruleset":
+      return mockedRuleset2;
+    case "fantastic-ruleset":
+      return mockedRuleset3;
+    default:
+      return null;
+  }
+}

--- a/tests/yaml.test.js
+++ b/tests/yaml.test.js
@@ -1,4 +1,5 @@
 import { parseYamlFile } from "../utils/file";
+import { convertRulesetsToString } from "../utils/ruleset";
 import {
   CODIGA_CONFIG_MISSING_RULESETS,
   CODIGA_CONFIG_MISSING_RULESETS_LIST,
@@ -19,4 +20,29 @@ test("parse a valid file accurately", async () => {
   expect(parseYamlFile(CODIGA_CONFIG_MISSING_RULESETS_VALID)).toEqual({
     rulesets: ["react-best-practices", "jsx-a11y"],
   });
+});
+
+test("ruleset is converted correctly", () => {
+  const input = ["codiga-ruleset"];
+  const output = "rulesets:\n" + "  - codiga-ruleset\n";
+  expect(convertRulesetsToString(input)).toBe(output);
+});
+
+test("empty strings are removed", () => {
+  const input = ["codiga-ruleset", "", "daniel-ruleset"];
+  const output =
+    "rulesets:\n" + "  - codiga-ruleset\n" + "  - daniel-ruleset\n";
+  expect(convertRulesetsToString(input)).toBe(output);
+});
+
+test("null values are removed", () => {
+  const input = ["codiga-ruleset", "", null];
+  const output = "rulesets:\n" + "  - codiga-ruleset\n";
+  expect(convertRulesetsToString(input)).toBe(output);
+});
+
+test("undefined values are removed", () => {
+  const input = ["codiga-ruleset", "", undefined];
+  const output = "rulesets:\n" + "  - codiga-ruleset\n";
+  expect(convertRulesetsToString(input)).toBe(output);
 });

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -6,6 +6,7 @@ export const ACTION_TOKEN_ADD = "token-add";
 export const ACTION_TOKEN_CHECK = "token-check";
 export const ACTION_TOKEN_DELETE = "token-delete";
 export const ACTION_GIT_PUSH_HOOK = "git-push-hook";
+export const ACTION_RULESET_ADD = "ruleset-add";
 
 // COMMAND OPTIONS
 export const OPTION_LANGUAGE = "language";

--- a/utils/file.js
+++ b/utils/file.js
@@ -2,7 +2,7 @@ import fs from "fs";
 import YAML from "yaml";
 import { extname } from "path";
 import { ROSIE_SUPPORTED_SUFFIX_TO_LANGUAGE } from "./constants";
-import { printFailure } from "./print";
+import { printEmptyLine, printFailure, printSuggestion } from "./print";
 
 /**
  * read a file contents
@@ -29,7 +29,14 @@ export function parseYamlFile(content, path) {
     const parsedFile = YAML.parse(content);
     return parsedFile;
   } catch (err) {
+    printEmptyLine();
     printFailure(`Unable to parse YAML file${path ? `: ${path}` : ""}`);
+    console.log(" ↳ Ensure your file is valid YAML syntax.");
+    printSuggestion(
+      " ↳ You can can use this online parser to check where your errors reside: ",
+      "https://jsonformatter.org/yaml-parser"
+    );
+    printEmptyLine();
     process.exit(1);
   }
 }

--- a/utils/file.js
+++ b/utils/file.js
@@ -5,16 +5,37 @@ import { ROSIE_SUPPORTED_SUFFIX_TO_LANGUAGE } from "./constants";
 import { printEmptyLine, printFailure, printSuggestion } from "./print";
 
 /**
- * read a file contents
+ * Used to read a file
+ * If the file doesn't exist, we'll return null
  * @param {string} path
  * @returns
  */
 export function readFile(path) {
   try {
+    return fs.readFileSync(path, "utf8");
+  } catch (err) {
+    return null;
+  }
+}
+
+/**
+ * Used to read a file
+ * If the file doesn't exist, we'll exit
+ * @param {string} path
+ * @returns
+ */
+export function readFileRequired(path) {
+  try {
     const file = fs.readFileSync(path, "utf8");
     return file;
   } catch (err) {
+    printEmptyLine();
     printFailure(`Unable to read file: ${path}`);
+    printSuggestion(
+      " ↳ Please try again and contact us, if the issue persists:",
+      "https://app.codiga.io/support"
+    );
+    printEmptyLine();
     process.exit(1);
   }
 }

--- a/utils/file.js
+++ b/utils/file.js
@@ -33,7 +33,7 @@ export function parseYamlFile(content, path) {
     printFailure(`Unable to parse YAML file${path ? `: ${path}` : ""}`);
     console.log(" ↳ Ensure your file is valid YAML syntax.");
     printSuggestion(
-      " ↳ You can can use this online parser to check where your errors reside: ",
+      " ↳ You can can use this online parser to check where your errors reside:",
       "https://jsonformatter.org/yaml-parser"
     );
     printEmptyLine();

--- a/utils/git.js
+++ b/utils/git.js
@@ -1,5 +1,5 @@
 import child_process from "child_process";
-import { printFailure } from "./print";
+import { printEmptyLine, printFailure, printSuggestion } from "./print";
 import { isTestMode } from "../tests/test-utils";
 
 /**
@@ -20,9 +20,9 @@ export function executeGitCommand(args) {
 
 /**
  * Gets the git directory
- * @returns the directory string or exits if there isn't one
+ * @returns the directory location or null if there isn't one
  */
-export function getRootDirectory() {
+export function getGitDirectory() {
   // if we're in test mode we'll skip this check
   if (isTestMode) return "./tests/fixtures";
 
@@ -31,9 +31,28 @@ export function getRootDirectory() {
   if (rootDirectory) {
     return rootDirectory.split("\n").join("");
   } else {
+    return null;
+  }
+}
+
+/**
+ * Gets the git directory
+ * @returns the directory location or exits if there isn't one
+ */
+export function getGitDirectoryRequired() {
+  // if we're in test mode we'll skip this check
+  if (isTestMode) return "./tests/fixtures";
+
+  // now look for a git repository
+  const rootDirectory = executeGitCommand(["rev-parse", "--show-toplevel"]);
+  if (rootDirectory) {
+    return rootDirectory.split("\n").join("");
+  } else {
+    printEmptyLine();
     printFailure(
       "Unable to execute a git command because you're not in a git repository"
     );
+    printEmptyLine();
     process.exit(1);
   }
 }
@@ -98,8 +117,9 @@ export function findClosestSha() {
 
   if (output) {
     closestSha = output.replace(/\n/g, "").trim();
-    console.debug(
-      `Closest SHA found between ${currentBranch} and ${mainBranch}: ${closestSha}`
+    printSuggestion(
+      `Closest SHA found between ${currentBranch} and ${mainBranch}`,
+      closestSha
     );
   }
 

--- a/utils/rosie.js
+++ b/utils/rosie.js
@@ -1,7 +1,7 @@
 import { Listr } from "listr2";
 import { encodeToBase64 } from "../utils/encoding";
 import { rosieApiFetch } from "./api";
-import { getLanguageForFile, readFile } from "./file";
+import { getLanguageForFile, readFileRequired } from "./file";
 import { getRulesForRosiePerLanguage } from "./rules";
 import { printEmptyLine, printFailure, printInfo, printSubItem } from "./print";
 
@@ -62,7 +62,7 @@ export async function analyzeFiles(paths, rules) {
 
     detectedLanguages.forEach((language) => {
       files[language].forEach((file) => {
-        const fileContent = readFile(file);
+        const fileContent = readFileRequired(file);
         const body = {
           filename: file,
           language: language.toLowerCase(),

--- a/utils/ruleset.js
+++ b/utils/ruleset.js
@@ -1,0 +1,21 @@
+import { GET_RULESET } from "../graphql/queries";
+import { getRulesetMock } from "../tests/fixtures/rulesetMock";
+import { isTestMode } from "../tests/test-utils";
+import { codigaApiFetch } from "./api";
+
+export async function getRuleset({ name }) {
+  try {
+    if (isTestMode) return getRulesetMock(name);
+    const resp = await codigaApiFetch(GET_RULESET, { name });
+    return resp.ruleSet;
+  } catch (err) {
+    return null;
+  }
+}
+
+export function convertRulesetsToString(rulesets) {
+  return `rulesets:\n${rulesets
+    .filter((x) => x)
+    .map((ruleset) => `  - ${ruleset}\n`)
+    .join("")}`;
+}

--- a/utils/rulesets.js
+++ b/utils/rulesets.js
@@ -1,7 +1,7 @@
-import { readFile, parseYamlFile } from "../utils/file";
+import { readFileRequired, parseYamlFile } from "../utils/file";
 import { codigaApiFetch } from "./api";
 import { ACTION_TOKEN_ADD, CODIGA_CONFIG_FILE } from "./constants";
-import { getRootDirectory } from "./git";
+import { getGitDirectoryRequired } from "./git";
 import { GET_RULESETS_FOR_CLIENT } from "../graphql/queries";
 import { printCommandSuggestion, printFailure, printSuggestion } from "./print";
 import { getToken } from "./store";
@@ -35,10 +35,10 @@ export async function getRulesetsWithRules(names) {
  * @returns
  */
 export function getRulesetsFromCodigaFile() {
-  const rootDir = getRootDirectory();
+  const rootDir = getGitDirectoryRequired();
 
   const codigaFileLocation = `${rootDir}/${CODIGA_CONFIG_FILE}`;
-  const file = readFile(codigaFileLocation);
+  const file = readFileRequired(codigaFileLocation);
   const parsedFile = parseYamlFile(file, codigaFileLocation);
 
   // if there isn't a rulesets value in the codiga.yml file, throw an error

--- a/utils/rulesets.js
+++ b/utils/rulesets.js
@@ -1,9 +1,14 @@
-import { readFileRequired, parseYamlFile } from "../utils/file";
+import { parseYamlFile, readFile } from "../utils/file";
 import { codigaApiFetch } from "./api";
 import { ACTION_TOKEN_ADD, CODIGA_CONFIG_FILE } from "./constants";
 import { getGitDirectoryRequired } from "./git";
 import { GET_RULESETS_FOR_CLIENT } from "../graphql/queries";
-import { printCommandSuggestion, printFailure, printSuggestion } from "./print";
+import {
+  printCommandSuggestion,
+  printEmptyLine,
+  printFailure,
+  printSuggestion,
+} from "./print";
 import { getToken } from "./store";
 
 /**
@@ -38,8 +43,22 @@ export function getRulesetsFromCodigaFile() {
   const rootDir = getGitDirectoryRequired();
 
   const codigaFileLocation = `${rootDir}/${CODIGA_CONFIG_FILE}`;
-  const file = readFileRequired(codigaFileLocation);
-  const parsedFile = parseYamlFile(file, codigaFileLocation);
+  const codigaFileContent = readFile(codigaFileLocation);
+  if (!codigaFileContent) {
+    printEmptyLine();
+    printFailure(`Unable to read a codiga.yml file`);
+    printSuggestion(
+      " ↳ Please ensure you have a codiga.yml here:",
+      codigaFileLocation
+    );
+    printSuggestion(
+      " ↳ Search for rulesets to add to it here:",
+      "https://app.codiga.io/hub/rulesets"
+    );
+    printEmptyLine();
+    process.exit(1);
+  }
+  const parsedFile = parseYamlFile(codigaFileContent, codigaFileLocation);
 
   // if there isn't a rulesets value in the codiga.yml file, throw an error
   if (!parsedFile) {


### PR DESCRIPTION
**Changes:**

- added a new command `ruleset-add <ruleset-name>`, which when invoked:
  - verifies the ruleset exists
  - checks for a `codiga.yml` file
    - if a git repository is detached, we look at that directory level
    - if not, we look at the current directory
  - if a `codiga.yml` was **not** found
    - we create one and add the ruleset to it
  - if a `codiga.yml` was found
    - we parse it and check it the ruleset is in it
      - if it is, we exit
      - if it isn't, we'll add it
- added tests for
  - the `ruleset-add` command
  - YAML parsing/writing
- improved some error messages for readability and clearer issue reporting
  - changed some utils to handle these better